### PR TITLE
fixes missing substates

### DIFF
--- a/evmcore/state_processor.go
+++ b/evmcore/state_processor.go
@@ -101,7 +101,6 @@ func (p *StateProcessor) Process(
 			return nil, nil, nil, fmt.Errorf("could not apply tx %d [%v]: %w", i, tx.Hash().Hex(), err)
 		}
 		if substate.RecordReplay {
-			fmt.Printf("Processed blk %v, tx %v, tx-hash %v, err %v\n", block.NumberU64(), txCounter, tx.Hash(), err)
 			// save tx substate into DBs, merge block hashes to env
 			etherBlock := block.RecordingEthBlock()
 			recording := substate.NewSubstate(


### PR DESCRIPTION
root cause: substates with the same tx number in a block overwrites each other. Substate of pre-internal and internal txs are overwritten by substate of external transactions with the same transaction number.

solution: add global variables tracking transaction counter. This adds unique transaction number to substate.